### PR TITLE
buildroot: bump to 2016.11

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,7 @@ MAKEARGS := -C $(CURDIR)/buildroot
 #location to store build files
 MAKEARGS += O=$(CURDIR)/$(PROJECT_NAME)/output
 # location to store extra config options and buildroot packages
-MAKEARGS += BR2_EXTERNAL=$(CURDIR)
+MAKEARGS += BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH=$(CURDIR)
 #transmit project name to be able to use it in kconfig
 MAKEARGS += PROJECT_NAME=$(PROJECT_NAME)
 # location of default defconfig
@@ -81,10 +81,10 @@ $(DEFCONFIG_FILE):
 	$(call UPDATE_DEFCONFIG)
 
 define UPDATE_DEFCONFIG
-	echo 'BR2_DL_DIR="$$(BR2_EXTERNAL)/dl"' >> $(DEFCONFIG_FILE)
-	echo 'BR2_ROOTFS_OVERLAY="$$(BR2_EXTERNAL)/overlay"' >> $(DEFCONFIG_FILE)
-	echo 'BR2_PACKAGE_OVERRIDE_FILE="$$(BR2_EXTERNAL)/local.mk"' >> $(DEFCONFIG_FILE)
-	echo 'BR2_GLOBAL_PATCH_DIR="$$(BR2_EXTERNAL)/patch"' >> $(DEFCONFIG_FILE)
+	echo 'BR2_DL_DIR="$$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/dl"' >> $(DEFCONFIG_FILE)
+	echo 'BR2_ROOTFS_OVERLAY="$$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/overlay"' >> $(DEFCONFIG_FILE)
+	echo 'BR2_PACKAGE_OVERRIDE_FILE="$$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/local.mk"' >> $(DEFCONFIG_FILE)
+	echo 'BR2_GLOBAL_PATCH_DIR="$$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/patch"' >> $(DEFCONFIG_FILE)
 	$(MAKE) $(MAKEARGS) $(DEFCONFIG) defconfig
 	$(MAKE) $(MAKEARGS) $(DEFCONFIG) savedefconfig
 endef

--- a/external.desc
+++ b/external.desc
@@ -1,0 +1,2 @@
+name: BUILDROOT_SUBMODULE
+desc: Buildroot submodule br2-external tree


### PR DESCRIPTION
Add extenal.desc file

"Before Buildroot 2016.11, it was possible to use only one br2-external
tree at once. With Buildroot 2016.11 came the possibility to use more
than one simultaneously."

1) Create a new file named external.desc, at the root of the Buildroot
submodule br2-external tree.

2) Change every occurence of BR2_EXTERNAL in Buildroot submodule
br2-external tree with the new BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH.

https://buildroot.org/downloads/manual/manual.html#br2-external-converting

Signed-off-by: Romain Naour <romain.naour@gmail.com>