### PR TITLE
One fix for external + documenting the build of GDB in external toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,34 @@ The idea is to make two variants of the same project, one to build the toolchain
 
 * Create a new _Makefile_ for the variant `cp Makefile Makefile.toolchain`
 * Edit the new file to rename the project to _toolchain_
-* Configure the new subproject properly with `make -f Makefile.toolchain menuconfig` 
- * Configure the toolchain itself according to your need
- * deactivate the linux kernel option
- * set init system to _None_ and deactivate busybox
+* Configure the new subproject properly with `make -f Makefile.toolchain menuconfig`
+  * Configure the toolchain itself according to your need
+  * deactivate the linux kernel option
+  * set init system to _None_ and deactivate busybox
 * make the toolchain with `make -f Makefile.toolchain toolchain`
 * configure your main project to use the built toolchain
- * change the toolchain type to _external toolchain_
- * set the toolchain location to _$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/toolchain/output/host/usr_
- * set all toolchain options to reflect what you have set in your toolchain project
+  * change the toolchain type to _external toolchain_
+  * set the toolchain location to _$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/toolchain/output/host/usr_
+  * set all toolchain options to reflect what you have set in your toolchain project
 * check that the configuration is correct : `make toolchain`
 
 you can now build your normal project and _make clean_ won't erase the compiler entirely
+
+## Adding gdb to the toolchain built separately
+The configuration decribed above does not include GDB in the toolchain, if you need it, follow the extra steps bellow (it can be done direcly).
+* Update the configuration of the toolchain subproject with `make -f Makefile.toolchain menuconfig`
+  * disable all rootfs specific tasks:
+    * disable root login with password
+    * set /bin/sh to none
+    * disable Run a getty (login prompt) after boot
+    * disable remount root filesystem read-write during boot
+    * disable all Filesystem images options (tar, ext, cpio...)
+  * select build cross gdb for the host and the options you need
+  * add the gdb + gdb-server package (from Target packages > Debugging, profiling and benchmark as for buildroot this is part of your rootfs, but here it's a very minimal one)
+* make the toolchain with `make -f Makefile.toolchain` (note the full build: you need to build the gdb-serveur target package)
+* update the configuration of your main project
+  * select Copy gdb server to the Target
+* check that the configuration is correct : `make toolchain`
 
 ## Some notes on configuration management
 One of the design goals of buildroot-submodule is to keep buildroot's _absolutely rebuildable_ philosophy. 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The idea is to make two variants of the same project, one to build the toolchain
 * make the toolchain with `make -f Makefile.toolchain toolchain`
 * configure your main project to use the built toolchain
  * change the toolchain type to _external toolchain_
- * set the toolchain location to _$(BR2_EXTERNAL)/toolchain/output/host/usr_
+ * set the toolchain location to _$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/toolchain/output/host/usr_
  * set all toolchain options to reflect what you have set in your toolchain project
 * check that the configuration is correct : `make toolchain`
 
@@ -167,9 +167,9 @@ This only applies for packages that are managed by buildroot proper. If the pack
 * add the following line to the file _local.mk_
 
 ```
- <packagename>_OVERRIDE_SRCDIR=$(BR2_EXTERNAL)/path/to/source
+ <packagename>_OVERRIDE_SRCDIR=$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/path/to/source
 ```
-   The variable _$(BR2_EXTERNAL)_ will expand to the toplevel directory of your project. Note that _packagename_ should be all cap here.
+   The variable _$(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)_ will expand to the toplevel directory of your project. Note that _packagename_ should be all cap here.
 
 Buildroot will use these source instead of the version recommande by its own configuration but will still use its internal knowledge of the package to compile it.
 
@@ -178,7 +178,7 @@ Once your changes are ready you can regenerate the patch serie, including the pa
 ### Customizing the final filesystem
 Usually, you want to customize your target filesystem by ovelaying files as described above in this document. But in some case it is not possible to use static files and running a shell script on the generated filesystem can be very handy.
 
-* set the script to run in the menuconfig option _system configuration => script to run before generating images_ (use $(BR2_EXTERNAL) to have a path relative to your toplevel project directory)
+* set the script to run in the menuconfig option _system configuration => script to run before generating images_ (use $(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH) to have a path relative to your toplevel project directory)
 * add the script at the proper place
 
 ### Adding your own documentation to a buildroot-submodule project
@@ -198,7 +198,7 @@ Buildroot has a very complete infrastructure to generate documentation based on 
 #
 ################################################################################
 
-FOO_SOURCES = $(sort $(wildcard $(BR2_EXTERNAL)/foo/*))
+FOO_SOURCES = $(sort $(wildcard $(BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH)/foo/*))
 $(eval $(call asciidoc-document))
 ```
 

--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,7 @@ MAKEARGS := -C $(CURDIR)/buildroot
 #location to store build files
 MAKEARGS += O=$(CURDIR)/$(PROJECT_NAME)/output
 # location to store extra config options and buildroot packages
-MAKEARGS += BR2_EXTERNAL_BUILDROOT_SUBMODULE_PATH=$(CURDIR)
+MAKEARGS += BR2_EXTERNAL=$(CURDIR)
 #transmit project name to be able to use it in kconfig
 MAKEARGS += PROJECT_NAME=$(PROJECT_NAME)
 # location of default defconfig


### PR DESCRIPTION
The fix to the infrastructure needed after buildroot external changes (Romain's fix was not enough for real usage) I tester this in my raspki project (before dieharder was accepted upstream)

The second commit is simply documenting the way to build gdb-server in the toolchain build (did this for a project while still at openwide but missed the doc...)